### PR TITLE
Fix OpenOCD build missing linuxgpiod adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Pico SDK Tools
 
-This repository is used to provide pre-built binaries of the SDK tools for Windows, MacOS, Raspberry Pi OS, and other Linux operating systems (builds performed on Ubuntu).
+This repository is used to provide pre-built binaries of the SDK tools for Windows, macOS, Raspberry Pi OS, and other Linux operating systems (builds performed on Ubuntu).
 These binaries are primarilly for use by the [pico-vscode](https://github.com/raspberrypi/pico-vscode) extension, and the release format is subject to change at any time.
 
-The tools currently included are
-* picotool
-* OpenOCD
-* pioasm
-* Risc-V Toolchain for Raspberry Pi OS - for other OSs, the extension uses the compilers from [Core-V](https://www.embecosm.com/resources/tool-chain-downloads/#corev)
+The tools currently included are:
+* **picotool**
+* **OpenOCD** (includes `linuxgpiod` and `cmsis-dap` adapters)
+* **pioasm**
+* **RISC-V Toolchain for Raspberry Pi OS** - for other OSs, the extension uses the compilers from [Core-V](https://www.embecosm.com/resources/tool-chain-downloads/#corev)

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -7,8 +7,8 @@ SKIP_RISCV=${SKIP_RISCV-0}
 SKIP_OPENOCD=${SKIP_OPENOCD-0}
 
 # Install prerequisites
-sudo apt install -y jq cmake libtool automake libusb-1.0-0-dev libhidapi-dev libftdi1-dev
-# Risc-V prerequisites
+sudo apt install -y jq cmake libtool automake libusb-1.0-0-dev libhidapi-dev libftdi1-dev libgpiod-dev
+# RISC-V prerequisites
 sudo apt install -y autoconf automake autotools-dev curl python3 python3-pip libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev ninja-build git cmake libglib2.0-dev libslirp-dev
 
 repos=$(cat config/repositories.json | jq -c '.repositories[]')
@@ -94,11 +94,11 @@ fi
 if [[ "$SKIP_RISCV" != 1 ]]; then
     # Package riscv toolchain separately as well
     version="14"
-    echo "Risc-V Toolchain version $version"
+    echo "RISC-V Toolchain version $version"
 
     filename="riscv-toolchain-${version}-${suffix}.tar.gz"
 
-    echo "Saving Risc-V Toolchain package to $filename"
+    echo "Saving RISC-V Toolchain package to $filename"
     pushd "$builddir/riscv-install/"
     tar -a -cf "$topd/bin/$filename" *
     popd


### PR DESCRIPTION
Added `libgpiod-dev` so OpenOCD will be compiled with `linuxgpiod` adapter support. ([#62](https://github.com/raspberrypi/pico-vscode/issues/62))