### PR TITLE
Add Device Tree Compiler build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,7 @@ jobs:
             bin/pico-sdk-tools-*-x64-win.zip
             bin/openocd-*-x64-win.zip
             bin/riscv-toolchain-*-x64-win.zip
+            bin/dtc-*-x64-win.zip
       - name: Add Release Asset
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
@@ -48,6 +49,7 @@ jobs:
             bin/pico-sdk-tools-*-x64-win.zip
             bin/openocd-*-x64-win.zip
             bin/riscv-toolchain-*-x64-win.zip
+            bin/dtc-*-x64-win.zip
 
   build_macos:
     name: Build MacOS
@@ -81,6 +83,7 @@ jobs:
             bin/pico-sdk-tools-*-mac.zip
             bin/openocd-*-mac.zip
             bin/riscv-toolchain-*.zip
+            bin/dtc-*-mac.tar.gz
       - name: Add Release Asset
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
@@ -90,6 +93,7 @@ jobs:
             bin/pico-sdk-tools-*-mac.zip
             bin/openocd-*-mac.zip
             bin/riscv-toolchain-*.zip
+            bin/dtc-*-mac.tar.gz
 
   build_linux:
     name: Build Linux
@@ -120,6 +124,7 @@ jobs:
             bin/pico-sdk-tools-*-lin.tar.gz
             bin/openocd-*-lin.tar.gz
             bin/riscv-toolchain-*-lin.tar.gz
+            bin/dtc-*-lin.tar.gz
       - name: Add Release Asset
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
@@ -129,3 +134,4 @@ jobs:
             bin/pico-sdk-tools-*-lin.tar.gz
             bin/openocd-*-lin.tar.gz
             bin/riscv-toolchain-*-lin.tar.gz
+            bin/dtc-*-lin.tar.gz

--- a/README.md
+++ b/README.md
@@ -8,3 +8,4 @@ The tools currently included are:
 * **OpenOCD** (includes `linuxgpiod` and `cmsis-dap` adapters)
 * **pioasm**
 * **RISC-V Toolchain**
+* **Device Tree Compiler**

--- a/build.ps1
+++ b/build.ps1
@@ -221,9 +221,9 @@ if (-not (Test-Path ".\build\openocd-install\$msysEnv") -and ($env:SKIP_OPENOCD 
   msys "cd build && ../packages/windows/openocd/build-openocd.sh"
 }
 
-if (-not (Test-Path ".\build\picotool-install\$msysEnv")) {
-  msys "cd build && ../packages/windows/picotool/build-picotool.sh $version"
-}
+#if (-not (Test-Path ".\build\picotool-install\$msysEnv")) {
+#  msys "cd build && ../packages/windows/picotool/build-picotool.sh $version"
+#}
 
 if (-not (Test-Path ".\build\dtc-install\$msysEnv")) {
   msys "cd build && ../packages/windows/dtc/build-dtc.sh $version"
@@ -270,15 +270,15 @@ exec { tar -a -cf "bin\$filename" -C "build\pico-sdk-tools\$msysEnv" '*' }
 
 # Package picotool separately as well
 
-$version = (cmd /c ".\build\picotool-install\$msysEnv\picotool\picotool.exe" version -s '2>&1')
-Write-Host "Picotool version $version"
+#$version = (cmd /c ".\build\picotool-install\$msysEnv\picotool\picotool.exe" version -s '2>&1')
+#Write-Host "Picotool version $version"
 
-$filename = 'picotool-{0}-{1}.zip' -f
-  $version,
-  $suffix
+#$filename = 'picotool-{0}-{1}.zip' -f
+#  $version,
+#  $suffix
 
-Write-Host "Saving picotool package to $filename"
-exec { tar -a -cf "bin\$filename" -C "build\picotool-install\$msysEnv" '*' }
+#Write-Host "Saving picotool package to $filename"
+#exec { tar -a -cf "bin\$filename" -C "build\picotool-install\$msysEnv" '*' }
 
 # Package dtc separately as well
 $versionOutput = & ".\build\dtc-install\$msysEnv\bin\dtc.exe" --version

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -7,7 +7,7 @@ SKIP_RISCV=${SKIP_RISCV-0}
 SKIP_OPENOCD=${SKIP_OPENOCD-0}
 
 # Install prerequisites
-sudo apt install -y jq cmake libtool automake libusb-1.0-0-dev libhidapi-dev libftdi1-dev
+sudo apt install -y jq cmake libtool automake libusb-1.0-0-dev libhidapi-dev libftdi1-dev bison flex
 # RISC-V prerequisites
 sudo apt install -y autoconf automake autotools-dev curl python3 python3-pip libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev ninja-build git cmake libglib2.0-dev libslirp-dev
 # RPi Only prerequisites
@@ -51,6 +51,7 @@ if [[ "$SKIP_RISCV" != 1 ]]; then
     ../packages/linux/riscv/build-riscv-gcc.sh
 fi
 ../packages/linux/picotool/build-picotool.sh
+../packages/linux/dtc/build-dtc.sh
 cd ..
 
 topd=$PWD
@@ -74,6 +75,15 @@ filename="picotool-${version}-${suffix}.tar.gz"
 
 echo "Saving picotool package to $filename"
 pushd "$builddir/picotool-install/"
+tar -a -cf "$topd/bin/$filename" * .keep
+popd
+
+# Package dtc separately as well
+version=$("./$builddir/dtc-install/bin/dtc" --version | awk '{print $3}')
+echo "Device Tree Compiler version $version"
+filename="dtc-${version}-${suffix}.zip"
+echo "Saving dtc package to $filename"
+pushd "$builddir/dtc-install/"
 tar -a -cf "$topd/bin/$filename" * .keep
 popd
 

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -50,7 +50,7 @@ if [[ "$SKIP_RISCV" != 1 ]]; then
     # Takes ages to build
     ../packages/linux/riscv/build-riscv-gcc.sh
 fi
-../packages/linux/picotool/build-picotool.sh
+#../packages/linux/picotool/build-picotool.sh
 ../packages/linux/dtc/build-dtc.sh
 cd ..
 
@@ -68,15 +68,15 @@ if [ ${version:0:1} -ge 2 ]; then
 fi
 
 # Package picotool separately as well
-version=$("./$builddir/picotool-install/picotool/picotool" version -s)
-echo "Picotool version $version"
+#version=$("./$builddir/picotool-install/picotool/picotool" version -s)
+#echo "Picotool version $version"
 
-filename="picotool-${version}-${suffix}.tar.gz"
+#filename="picotool-${version}-${suffix}.tar.gz"
 
-echo "Saving picotool package to $filename"
-pushd "$builddir/picotool-install/"
-tar -a -cf "$topd/bin/$filename" * .keep
-popd
+#echo "Saving picotool package to $filename"
+#pushd "$builddir/picotool-install/"
+#tar -a -cf "$topd/bin/$filename" * .keep
+#popd
 
 # Package dtc separately as well
 version=$("./$builddir/dtc-install/bin/dtc" --version | awk '{print $3}')

--- a/build_macos.sh
+++ b/build_macos.sh
@@ -7,8 +7,8 @@ SKIP_RISCV=${SKIP_RISCV-0}
 SKIP_OPENOCD=${SKIP_OPENOCD-0}
 
 # Install prerequisites
-arch -x86_64 /usr/local/bin/brew install jq libtool libusb automake hidapi --quiet
-arch -arm64 /opt/homebrew/bin/brew install jq libtool libusb automake hidapi --quiet
+arch -x86_64 /usr/local/bin/brew install jq libtool libusb automake hidapi bison flex pkgconf --quiet
+arch -arm64 /opt/homebrew/bin/brew install jq libtool libusb automake hidapi bison flex pkgconf --quiet
 # RISC-V prerequisites
 echo "Listing local"
 ls /usr/local/bin
@@ -60,6 +60,9 @@ fi
 arch -x86_64 ../packages/macos/picotool/build-picotool.sh
 arch -arm64 ../packages/macos/picotool/build-picotool.sh
 ../packages/macos/picotool/merge-picotool.sh
+
+arch -x86_64 ../packages/macos/dtc/build-dtc.sh
+arch -arm64 ../packages/macos/dtc/build-dtc.sh
 cd ..
 
 topd=$PWD
@@ -83,6 +86,15 @@ filename="picotool-${version}-${suffix}.zip"
 echo "Saving picotool package to $filename"
 pushd "$builddir/picotool-install/"
 tar -a -cf "$topd/bin/$filename" * .keep
+popd
+
+# Package dtc separately as well
+version=$("./$builddir/dtc-install/bin/dtc" --version | awk '{print $3}')
+echo "Device Tree Compiler version $version"
+filename="dtc-${version}-${suffix}.zip"
+echo "Saving dtc package to $filename"
+pushd "$builddir/dtc-install/"
+zip -yr "$topd/bin/$filename" * .keep
 popd
 
 if [[ "$SKIP_OPENOCD" != 1 ]] && [[ $(uname -m) == 'arm64' ]]; then

--- a/build_macos.sh
+++ b/build_macos.sh
@@ -57,9 +57,9 @@ if [[ "$SKIP_RISCV" != 1 ]]; then
     # Takes ages to build
     ../packages/macos/riscv/build-riscv-gcc.sh
 fi
-arch -x86_64 ../packages/macos/picotool/build-picotool.sh
-arch -arm64 ../packages/macos/picotool/build-picotool.sh
-../packages/macos/picotool/merge-picotool.sh
+#arch -x86_64 ../packages/macos/picotool/build-picotool.sh
+#arch -arm64 ../packages/macos/picotool/build-picotool.sh
+#../packages/macos/picotool/merge-picotool.sh
 
 arch -x86_64 ../packages/macos/dtc/build-dtc.sh
 arch -arm64 ../packages/macos/dtc/build-dtc.sh
@@ -78,15 +78,15 @@ if [ ${version:0:1} -ge 2 ]; then
 fi
 
 # Package picotool separately as well
-version=$("./$builddir/picotool-install/picotool/picotool" version -s)
-echo "Picotool version $version"
+#version=$("./$builddir/picotool-install/picotool/picotool" version -s)
+#echo "Picotool version $version"
 
-filename="picotool-${version}-${suffix}.zip"
+#filename="picotool-${version}-${suffix}.zip"
 
-echo "Saving picotool package to $filename"
-pushd "$builddir/picotool-install/"
-tar -a -cf "$topd/bin/$filename" * .keep
-popd
+#echo "Saving picotool package to $filename"
+#pushd "$builddir/picotool-install/"
+#tar -a -cf "$topd/bin/$filename" * .keep
+#popd
 
 # Package dtc separately as well
 version=$("./$builddir/dtc-install/bin/dtc" --version | awk '{print $3}')

--- a/config/repositories.json
+++ b/config/repositories.json
@@ -19,6 +19,10 @@
     {
       "href": "https://github.com/gcc-mirror/gcc",
       "tree": "releases/gcc-14"
+    },
+    {
+      "href": "https://git.kernel.org/pub/scm/utils/dtc/dtc.git",
+      "tree": "v1.7.2"
     }
   ]
 }

--- a/packages/linux/dtc/build-dtc.sh
+++ b/packages/linux/dtc/build-dtc.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -euo pipefail
+
+cd dtc
+
+# build
+make clean
+make -j$(nproc) NO_PYTHON=1
+
+INSTALLDIR="$PWD/../dtc-install"
+make NO_PYTHON=1 DESTDIR="$INSTALLDIR" PREFIX="" install

--- a/packages/macos/dtc/build-dtc.sh
+++ b/packages/macos/dtc/build-dtc.sh
@@ -1,0 +1,59 @@
+#!/bin/zsh
+
+set -euo pipefail
+
+# Drop git repo of dtc as we use brew to build
+rm -rf dtc
+mkidr -p dtc-install
+cd dtc-install
+
+arch -x86_64 /usr/local/bin/brew install --build-from-source dtc
+arch -arm64 /opt/homebrew/bin/brew install --build-from-source dtc
+
+# Copy the dtc binaries to the build directory
+BREW_PREFIX_X86=$(arch -x86_64 /usr/local/bin/brew --prefix)
+BREW_PREFIX_ARM64=$(arch -arm64 /opt/homebrew/bin/brew --prefix)
+
+cp -R "$BREW_PREFIX_X86/Cellar/dtc/$(arch -x86_64 /usr/local/bin/brew list --versions dtc | awk '{print $2}')" ./dtc-x86
+cp -R "$BREW_PREFIX_ARM64/Cellar/dtc/$(arch -arm64 /opt/homebrew/bin/brew list --versions dtc | awk '{print $2}')" ./dtc-arm64
+
+# Create universal distribution
+mkdir -p dtc-universal/{bin,lib}
+
+for binary in dtc fdtdump fdtoverlay fdtput fdtget dtdiff convert-dtsv0; do
+  lipo -create \
+    dtc-arm64/bin/$binary \
+    dtc-x86/bin/$binary \
+    -output dtc-universal/bin/$binary
+done
+
+VERSIONED_DYLIB=$(basename "$(find dtc-arm64/lib -name 'libfdt.dylib.*' | head -n 1)")
+
+lipo -create \
+  dtc-arm64/lib/$VERSIONED_DYLIB \
+  dtc-x86/lib/$VERSIONED_DYLIB \
+  -output dtc-universal/lib/$VERSIONED_DYLIB
+
+lipo -create \
+  dtc-arm64/lib/libfdt.a \
+  dtc-x86/lib/libfdt.a \
+  -output dtc-universal/lib/libfdt.a
+
+# Recreate symlinks
+cd dtc-universal/lib
+ln -sf $VERSIONED_DYLIB libfdt.1.dylib
+ln -sf libfdt.1.dylib libfdt.dylib
+cd ../../
+
+cp -R dtc-arm64/include dtc-universal/
+cp -R dtc-arm64/README.md dtc-universal/
+
+# clean up
+rm -rf dtc-arm64
+rm -rf dtc-x86
+
+# move every folder and file from dtc-universal to .
+mv dtc-universal/* .
+rmdir dtc-universal
+
+cd ..

--- a/packages/macos/dtc/build-dtc.sh
+++ b/packages/macos/dtc/build-dtc.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 # Drop git repo of dtc as we use brew to build
 rm -rf dtc
-mkidr -p dtc-install
+mkdir -p dtc-install
 cd dtc-install
 
 arch -x86_64 /usr/local/bin/brew install --build-from-source dtc

--- a/packages/windows/dtc/build-dtc.sh
+++ b/packages/windows/dtc/build-dtc.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -euo pipefail
+
+BUILDDIR=$(pwd)
+INSTALLDIR="dtc-install"
+
+cd dtc
+make clean
+make -j$(nproc) NO_PYTHON=1
+
+make NO_PYTHON=1 DESTDIR="$BUILDDIR/$INSTALLDIR" PREFIX="" install
+
+cd "$BUILDDIR/$INSTALLDIR/${MSYSTEM,,}/bin"
+"$BUILDDIR/../packages/windows/copy-deps.sh"


### PR DESCRIPTION
This PR adds build scripts for Device Tree Compiler. I was not able to test it yet on GitHub runners because the Linux and Windows workflows fail before it is run. 