### PR TITLE
Use fixed msys2 version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,13 +17,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup MSYS2
-        uses: msys2/setup-msys2@v2
       - name: Build
         run: |
           subst P: .
           P:
-          ./build.ps1 ./config/x64-win.json -SkipSigning -MSYS2Path (msys2 -c 'cygpath -m /').TrimEnd('\/')
+          ./build.ps1 ./config/x64-win.json -SkipSigning
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:

--- a/build.ps1
+++ b/build.ps1
@@ -203,9 +203,10 @@ $env:MSYS = "winsymlinks:nativestrict"
 if (-not $SkipDownload) {
   # First run setup
   msys 'uname -a'
-  # Core update
-  msys 'pacman --noconfirm -Syuu'
-  # Normal update
+  # Don't sync the package database (-Sy) so pacman uses the local database
+  # from the pinned MSYS2 installer snapshot, which lists GCC 14. Running
+  # -Sy would pull the current database and upgrade to GCC 16+, which breaks
+  # the riscv-gnu-toolchain build (GCC 16 defaults to C++23, libcody fails).
   msys 'pacman --noconfirm -Suu'
 
   msys "pacman -S --noconfirm --needed autoconf automake base-devel expat git libtool pactoys patchutils pkg-config"

--- a/config/tools.json
+++ b/config/tools.json
@@ -1,16 +1,9 @@
 {
   "tools": [
     {
-      "name": "NSIS",
-      "file": "nsis-3.08.zip",
-      "href": "https://sourceforge.net/projects/nsis/files/NSIS%203/3.08/nsis-3.08.zip/download",
-      "dirName": "NSIS",
-      "extractStrip": 1
-    },
-    {
       "name": "MSYS2",
       "file": "msys2.exe",
-      "href": "https://github.com/msys2/msys2-installer/releases/download/2024-12-08/msys2-base-x86_64-20241208.sfx.exe"
+      "href": "https://github.com/msys2/msys2-installer/releases/download/2025-12-13/msys2-base-x86_64-20251213.sfx.exe"
     }
   ]
 }


### PR DESCRIPTION
Use fixed msys2 version, as the latest version has a compiler too new, which throws an error when compiling the Risc-V toolchain