### PR TITLE
Correct script dir

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -265,7 +265,7 @@ exec { tar -a -cf "bin\$filename" -C "build\picotool-install\$msysEnv" '*' }
 if ($env:SKIP_OPENOCD -ne '1') {
   # Package OpenOCD separately as well
 
-  $version = (cmd /c ".\build\openocd-install\$msysEnv\bin\openocd.exe" --version '2>&1')[0]
+  $version = (cmd /c ".\build\openocd-install\openocd\openocd.exe" --version '2>&1')[0]
   if (-not ($version -match 'Open On-Chip Debugger (?<version>[a-zA-Z0-9\.\-+]+) \((?<timestamp>[0-9\-:]+)\)')) {
     Write-Error 'Could not determine openocd version'
   }
@@ -276,10 +276,10 @@ if ($env:SKIP_OPENOCD -ne '1') {
 
   # Removing files with special char in their names
   # they cause issues with some decompression libraries
-  Remove-Item "build\openocd-install\$msysEnv\share\openocd\scripts\target\1986*.cfg"
+  Remove-Item "build\openocd-install\openocd\scripts\target\1986*.cfg"
 
   Write-Host "Saving OpenOCD package to $filename"
-  exec { tar -a -cf "bin\$filename" -C "build\openocd-install\$msysEnv\bin" '*' -C "..\share\openocd" "scripts" }
+  exec { tar -a -cf "bin\$filename" -C "build\openocd-install\openocd" '*' }
 }
 
 if ($env:SKIP_RISCV -ne '1') {

--- a/build.ps1
+++ b/build.ps1
@@ -265,7 +265,7 @@ exec { tar -a -cf "bin\$filename" -C "build\picotool-install\$msysEnv" '*' }
 if ($env:SKIP_OPENOCD -ne '1') {
   # Package OpenOCD separately as well
 
-  $version = (cmd /c ".\build\openocd-install\openocd\openocd.exe" --version '2>&1')[0]
+  $version = (cmd /c ".\build\openocd-install\install\openocd\openocd.exe" --version '2>&1')[0]
   if (-not ($version -match 'Open On-Chip Debugger (?<version>[a-zA-Z0-9\.\-+]+) \((?<timestamp>[0-9\-:]+)\)')) {
     Write-Error 'Could not determine openocd version'
   }
@@ -276,10 +276,10 @@ if ($env:SKIP_OPENOCD -ne '1') {
 
   # Removing files with special char in their names
   # they cause issues with some decompression libraries
-  Remove-Item "build\openocd-install\openocd\scripts\target\1986*.cfg"
+  Remove-Item "build\openocd-install\install\openocd\scripts\target\1986*.cfg"
 
   Write-Host "Saving OpenOCD package to $filename"
-  exec { tar -a -cf "bin\$filename" -C "build\openocd-install\openocd" '*' }
+  exec { tar -a -cf "bin\$filename" -C "build\openocd-install\install\openocd" '*' }
 }
 
 if ($env:SKIP_RISCV -ne '1') {

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -84,7 +84,7 @@ popd
 if [[ "$SKIP_OPENOCD" != 1 ]]; then
     # Package OpenOCD separately as well
 
-    version=($("./$builddir/openocd-install/usr/local/bin/openocd" --version 2>&1))
+    version=($("./$builddir/openocd-install/openocd/openocd" --version 2>&1))
     version=${version[0]}
     version=${version[3]}
     version=$(echo $version | cut -d "-" -f 1)
@@ -94,8 +94,8 @@ if [[ "$SKIP_OPENOCD" != 1 ]]; then
     filename="openocd-${version}-${suffix}.tar.gz"
 
     echo "Saving OpenOCD package to $filename"
-    pushd "$builddir/openocd-install/usr/local/bin"
-    tar -a -cf "$topd/bin/$filename" * -C "../share/openocd" "scripts"
+    pushd "$builddir/openocd-install/openocd"
+    tar -a -cf "$topd/bin/$filename" *
     popd
 fi
 

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -84,7 +84,7 @@ popd
 if [[ "$SKIP_OPENOCD" != 1 ]]; then
     # Package OpenOCD separately as well
 
-    version=($("./$builddir/openocd-install/openocd/openocd" --version 2>&1))
+    version=($("./$builddir/openocd-install/install/openocd/openocd" --version 2>&1))
     version=${version[0]}
     version=${version[3]}
     version=$(echo $version | cut -d "-" -f 1)
@@ -94,7 +94,7 @@ if [[ "$SKIP_OPENOCD" != 1 ]]; then
     filename="openocd-${version}-${suffix}.tar.gz"
 
     echo "Saving OpenOCD package to $filename"
-    pushd "$builddir/openocd-install/openocd"
+    pushd "$builddir/openocd-install/install/openocd"
     tar -a -cf "$topd/bin/$filename" *
     popd
 fi

--- a/merge_macos.sh
+++ b/merge_macos.sh
@@ -64,7 +64,7 @@ if [[ "$SKIP_OPENOCD" != 1 ]]; then
     echo "Packaging OpenOCD"
     # Package OpenOCD separately as well
 
-    version=($("./$builddir/openocd-install/openocd/openocd" --version 2>&1))
+    version=($("./$builddir/openocd-install/install/openocd/openocd" --version 2>&1))
     version=${version[0]}
     version=${version[3]}
     version=$(echo $version | cut -d "-" -f 1)
@@ -74,7 +74,7 @@ if [[ "$SKIP_OPENOCD" != 1 ]]; then
     filename="openocd-${version}-${suffix}.zip"
 
     echo "Saving OpenOCD package to $filename"
-    pushd "$builddir/openocd-install/openocd"
+    pushd "$builddir/openocd-install/install/openocd"
     tar -a -cf "$topd/bin/$filename" *
     popd
 fi

--- a/merge_macos.sh
+++ b/merge_macos.sh
@@ -64,7 +64,7 @@ if [[ "$SKIP_OPENOCD" != 1 ]]; then
     echo "Packaging OpenOCD"
     # Package OpenOCD separately as well
 
-    version=($("./$builddir/openocd-install/usr/local/bin/openocd" --version 2>&1))
+    version=($("./$builddir/openocd-install/openocd/openocd" --version 2>&1))
     version=${version[0]}
     version=${version[3]}
     version=$(echo $version | cut -d "-" -f 1)
@@ -74,8 +74,8 @@ if [[ "$SKIP_OPENOCD" != 1 ]]; then
     filename="openocd-${version}-${suffix}.zip"
 
     echo "Saving OpenOCD package to $filename"
-    pushd "$builddir/openocd-install/usr/local/bin"
-    tar -a -cf "$topd/bin/$filename" * -C "../share/openocd" "scripts"
+    pushd "$builddir/openocd-install/openocd"
+    tar -a -cf "$topd/bin/$filename" *
     popd
 fi
 

--- a/packages/linux/openocd/build-openocd.sh
+++ b/packages/linux/openocd/build-openocd.sh
@@ -5,17 +5,22 @@ set -euo pipefail
 export CFLAGS=-static
 export LDFLAGS=-static
 
+BUILDDIR=$(pwd)
+INSTALLDIR="openocd-install"
+BINDIR="/openocd"
+DATADIR="/"
+
 cd openocd
 ./bootstrap
-./configure --disable-werror --enable-internal-jimtcl
+./configure --disable-werror --enable-internal-jimtcl --bindir="$BINDIR" --datadir="$DATADIR"
 make clean
 make
-INSTALLDIR="$PWD/../openocd-install/usr/local/bin"
-rm -rf "$PWD/../openocd-install"
-DESTDIR="$PWD/../openocd-install" make install
+rm -rf "$BUILDDIR/$INSTALLDIR"
+DESTDIR="$BUILDDIR/$INSTALLDIR" make install
 
 # Add libraries that may be different versions on the system
-cd $INSTALLDIR
+cd "$BUILDDIR/$INSTALLDIR/$BINDIR"
+find . -maxdepth 1 ! -name . ! -name .. ! -name openocd ! -name scripts -exec rm -r {} +
 if [[ $(uname -m) == 'aarch64' ]]; then
     cp $(ldd openocd | egrep -o "(/.*/libgpiod\.so\.\S*)") ./
 fi

--- a/packages/linux/openocd/build-openocd.sh
+++ b/packages/linux/openocd/build-openocd.sh
@@ -7,8 +7,8 @@ export LDFLAGS=-static
 
 BUILDDIR=$(pwd)
 INSTALLDIR="openocd-install"
-BINDIR="/openocd"
-DATADIR="/"
+BINDIR="/install/openocd"
+DATADIR="/install"
 
 cd openocd
 ./bootstrap

--- a/packages/macos/openocd/build-openocd.sh
+++ b/packages/macos/openocd/build-openocd.sh
@@ -2,14 +2,21 @@
 
 set -euo pipefail
 
+BUILDDIR=$(pwd)
+INSTALLDIR="openocd-install-$(uname -m)"
+BINDIR="/openocd"
+DATADIR="/"
+
 cd openocd
 
 ./bootstrap
 # See https://github.com/raspberrypi/openocd/issues/30
 # ./configure --disable-werror CAPSTONE_CFLAGS="$(pkg-config capstone --cflags | sed s/.capstone\$//)"
-./configure --disable-werror --enable-internal-jimtcl
+./configure --disable-werror --enable-internal-jimtcl --bindir="$BINDIR" --datadir="$DATADIR"
 make clean
 make
-INSTALLDIR="$PWD/../openocd-install-$(uname -m)/usr/local/bin"
-rm -rf "$PWD/../openocd-install-$(uname -m)"
-DESTDIR="$PWD/../openocd-install-$(uname -m)" make install
+rm -rf "$BUILDDIR/$INSTALLDIR"
+DESTDIR="$BUILDDIR/$INSTALLDIR" make install
+
+cd "$BUILDDIR/$INSTALLDIR/$BINDIR"
+find . -maxdepth 1 ! -name . ! -name .. ! -name openocd ! -name scripts -exec rm -r {} +

--- a/packages/macos/openocd/build-openocd.sh
+++ b/packages/macos/openocd/build-openocd.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 
 BUILDDIR=$(pwd)
 INSTALLDIR="openocd-install-$(uname -m)"
-BINDIR="/openocd"
-DATADIR="/"
+BINDIR="/install/openocd"
+DATADIR="/install"
 
 cd openocd
 

--- a/packages/windows/openocd/build-openocd.sh
+++ b/packages/windows/openocd/build-openocd.sh
@@ -4,14 +4,17 @@ set -euo pipefail
 
 BUILDDIR=$(pwd)
 INSTALLDIR="openocd-install"
+BINDIR="/openocd"
+DATADIR="/"
 
 cd openocd
 
 ./bootstrap
-./configure --disable-werror --enable-internal-jimtcl
+./configure --disable-werror --enable-internal-jimtcl --bindir="$BINDIR" --datadir="$DATADIR"
 make clean
 make
 DESTDIR="$BUILDDIR/$INSTALLDIR" make install
 
-cd "$BUILDDIR/$INSTALLDIR/${MSYSTEM,,}/bin"
+cd "$BUILDDIR/$INSTALLDIR/$BINDIR"
+find . -maxdepth 1 ! -name . ! -name .. ! -name openocd.exe ! -name scripts -exec rm -r {} +
 "$BUILDDIR/../packages/windows/copy-deps.sh"

--- a/packages/windows/openocd/build-openocd.sh
+++ b/packages/windows/openocd/build-openocd.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 
 BUILDDIR=$(pwd)
 INSTALLDIR="openocd-install"
-BINDIR="/openocd"
-DATADIR="/"
+BINDIR="/install/openocd"
+DATADIR="/install"
 
 cd openocd
 


### PR DESCRIPTION
This overrides OpenOCD paths to ensure `bin2data` ends up empty, so it searches the script dir next to the executable

Fixes #22 